### PR TITLE
Bug: inadvertent hardcoded loop to 10 iterations

### DIFF
--- a/src/GifCreate.php
+++ b/src/GifCreate.php
@@ -109,7 +109,7 @@ class GifCreate
      * @param int  $durations
      * @param null $loop
      *
-     * @return \pomirleanu\GifCreate\GifCreate
+     * @return \Pomirleanu\GifCreate\GifCreate
      * @throws \Exception
      */
     public function create($frames, $durations = 10, $loop = null)
@@ -117,7 +117,9 @@ class GifCreate
         if (count($frames) < 2) {
             throw new \Exception(sprintf($this->errors[ 'ERR06' ]));
         }
-        $this->setIfSet($durations, $loop);
+
+        // Update loop value if passed in.
+        $this->mergeConfigIfSet('loop', $loop);
 
         // Check if $frames is a dir; get all files in ascending order if yes (else die):
         if (! is_array($frames)) {
@@ -146,14 +148,18 @@ class GifCreate
         return $this->buildFrameSources($frames, $durations);
     }
 
-
-    private function setIfSet($loop)
+    /**
+     * If value is non-null value, overwrite or add to internal config.
+     *
+     * @param $key
+     * @param $value
+     */
+    private function mergeConfigIfSet($key, $value)
     {
-        if ($loop !== null) {
-            $this->config[ 'loop' ] = $loop;
+        if ($value !== null) {
+            $this->config[$key] = $value;
         }
     }
-
 
     /**
      * Building the frame sources for the given images


### PR DESCRIPTION
## Description

The value for `$duration` that is passed to `GifCreate::create()`, which defaults to 10, is run through `::setIfSet()`. This function overwrites the config for amount of loops. So the default behaviour of the created gif is to loop 10 times, even though the default behaviour is expected to be infinite looping.
## Motivation and context

It makes the behaviour of the animated gif as expected from both the docs and the `::create()` method signature.
## How has this been tested?

A three frame animated gif was generated before and after the change. Before it stops looping after 10 times, after change it loops infinitely.
## Screenshots (if appropriate)
## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
- [x] My code follows the code style of this project.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
